### PR TITLE
changes env priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ If the defaults do not cut it for your project, this outlines the available opti
       "blacklist": null, // DEPRECATED
       "whitelist": null, // DEPRECATED
       "safe": false,
-      "allowUndefined": true
+      "allowUndefined": true,
+      "verbose": false
     }]
   ]
 }

--- a/__tests__/__fixtures__/verbose/.babelrc
+++ b/__tests__/__fixtures__/verbose/.babelrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    ["../../../", {
+      "path": "__tests__/__fixtures__/default/.env",
+      "verbose": true
+    }]
+  ]
+}

--- a/__tests__/__fixtures__/verbose/.env
+++ b/__tests__/__fixtures__/verbose/.env
@@ -1,0 +1,2 @@
+API_KEY=abc123
+DEV_USERNAME=username

--- a/__tests__/__fixtures__/verbose/source.js
+++ b/__tests__/__fixtures__/verbose/source.js
@@ -1,0 +1,4 @@
+import {API_KEY, DEV_USERNAME} from '@env'
+
+console.log(API_KEY)
+console.log(DEV_USERNAME)

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -32,6 +32,13 @@ describe('react-native-dotenv', () => {
     expect(code).toBe('console.log("abc123");\nconsole.log("username");')
   })
 
+  it('should print the environment if setting to verbose', () => {
+    console.log = jest.fn();
+    const {code} = transformFileSync(FIXTURES + 'verbose/source.js')
+    expect(code).toBe('console.log("abc123");\nconsole.log("username");')
+    expect(console.log.mock.calls[0][1]).toBe('test');
+  })
+
   it('should allow importing variables already defined in the environment', () => {
     process.env.FROM_ENV = 'hello'
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -33,10 +33,10 @@ describe('react-native-dotenv', () => {
   })
 
   it('should print the environment if setting to verbose', () => {
-    console.log = jest.fn();
+    console.log = jest.fn()
     const {code} = transformFileSync(FIXTURES + 'verbose/source.js')
     expect(code).toBe('console.log("abc123");\nconsole.log("username");')
-    expect(console.log.mock.calls[0][1]).toBe('test');
+    expect(console.log.mock.calls[0][1]).toBe('test')
   })
 
   it('should allow importing variables already defined in the environment', () => {

--- a/index.js
+++ b/index.js
@@ -80,14 +80,14 @@ module.exports = ({types: t}) => ({
             if (Array.isArray(opts.allowlist) && !opts.allowlist.includes(importedId)) {
               throw path.get('specifiers')[idx].buildCodeFrameError(`"${importedId}" was not present in allowlist`)
             } else if (Array.isArray(opts.whitelist) && !opts.whitelist.includes(importedId)) {
-              console.error('[DEPRECATION WARNING] This option is will be deprecated soon. Use allowlist instead')
+              console.warn('[DEPRECATION WARNING] This option is will be deprecated soon. Use allowlist instead')
               throw path.get('specifiers')[idx].buildCodeFrameError(`"${importedId}" was not whitelisted`)
             }
 
             if (Array.isArray(opts.blocklist) && opts.blocklist.includes(importedId)) {
               throw path.get('specifiers')[idx].buildCodeFrameError(`"${importedId}" was not present in blocklist`)
             } else if (Array.isArray(opts.blacklist) && opts.blacklist.includes(importedId)) {
-              console.error('[DEPRECATION WARNING] This option is will be deprecated soon. Use blocklist instead')
+              console.warn('[DEPRECATION WARNING] This option is will be deprecated soon. Use blocklist instead')
               throw path.get('specifiers')[idx].buildCodeFrameError(`"${importedId}" was blacklisted`)
             }
 

--- a/index.js
+++ b/index.js
@@ -31,10 +31,15 @@ module.exports = ({types: t}) => ({
       blocklist: null,
       safe: false,
       allowUndefined: true,
+      verbose: false,
       ...this.opts
     }
 
-    const babelMode = process.env.APP_ENV || (process.env.BABEL_ENV && process.env.BABEL_ENV !== 'undefined' && process.env.BABEL_ENV) || process.env.NODE_ENV || 'development'
+    const babelMode = process.env.APP_ENV || (process.env.BABEL_ENV && process.env.BABEL_ENV !== 'undefined' && process.env.BABEL_ENV !== 'development' && process.env.BABEL_ENV) || process.env.NODE_ENV || 'development'
+    if (this.opts.verbose) {
+      console.log('dotenvMode', babelMode)
+    }
+
     if (this.opts.safe) {
       const parsed = parseDotenvFile(this.opts.path, this.opts.verbose)
       const localParsed = parseDotenvFile(this.opts.path + '.local')
@@ -75,14 +80,14 @@ module.exports = ({types: t}) => ({
             if (Array.isArray(opts.allowlist) && !opts.allowlist.includes(importedId)) {
               throw path.get('specifiers')[idx].buildCodeFrameError(`"${importedId}" was not present in allowlist`)
             } else if (Array.isArray(opts.whitelist) && !opts.whitelist.includes(importedId)) {
-              console.warn('[DEPRECATION WARNING] This option is will be deprecated soon. Use allowlist instead')
+              console.error('[DEPRECATION WARNING] This option is will be deprecated soon. Use allowlist instead')
               throw path.get('specifiers')[idx].buildCodeFrameError(`"${importedId}" was not whitelisted`)
             }
 
             if (Array.isArray(opts.blocklist) && opts.blocklist.includes(importedId)) {
               throw path.get('specifiers')[idx].buildCodeFrameError(`"${importedId}" was not present in blocklist`)
             } else if (Array.isArray(opts.blacklist) && opts.blacklist.includes(importedId)) {
-              console.warn('[DEPRECATION WARNING] This option is will be deprecated soon. Use blocklist instead')
+              console.error('[DEPRECATION WARNING] This option is will be deprecated soon. Use blocklist instead')
               throw path.get('specifiers')[idx].buildCodeFrameError(`"${importedId}" was blacklisted`)
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-dotenv",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Load environment variables using import statements.",
   "repository": "github:goatandsheep/react-native-dotenv",
   "homepage": "https://github.com/goatandsheep/react-native-dotenv",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-dotenv",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Load environment variables using import statements.",
   "repository": "github:goatandsheep/react-native-dotenv",
   "homepage": "https://github.com/goatandsheep/react-native-dotenv",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,13 @@
   "keywords": [
     "dotenv",
     "babel-plugin",
+    "babel",
+    "dotenv-flow",
     "react",
-    "react-native"
+    "react-native",
+    "config",
+    "env",
+    "12factor"
   ],
   "dependencies": {
     "dotenv": "^10.0.0"


### PR DESCRIPTION
## Link to issue ##

fixes #197

## Description of changes being made ##

* since `BABEL_ENV` defaults to `development` in certain cases, we made `NODE_ENV` higher priority than `BABEL_ENV` if that is true
* also fixes `console.warn` deprecation
* added a `verbose` option
