### PR TITLE
add support for multi-env local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ reports
 .nyc_output
 
 .vs
+.idea

--- a/index.js
+++ b/index.js
@@ -44,8 +44,13 @@ module.exports = ({types: t}) => ({
       const parsed = parseDotenvFile(this.opts.path, this.opts.verbose)
       const localParsed = parseDotenvFile(this.opts.path + '.local')
       const modeParsed = parseDotenvFile(this.opts.path + '.' + babelMode)
-      this.env = Object.assign(Object.assign(parsed, modeParsed), localParsed)
+      const modeLocalParsed = parseDotenvFile(this.opts.path + '.' + babelMode + '.local')
+      this.env = Object.assign(Object.assign(Object.assign(parsed, modeParsed), localParsed), modeLocalParsed)
     } else {
+      dotenv.config({
+        path: this.opts.path + '.' + babelMode + '.local',
+        silent: true
+      })
       dotenv.config({
         path: this.opts.path + '.' + babelMode,
         silent: true


### PR DESCRIPTION
## Link to issue ##
https://github.com/goatandsheep/react-native-dotenv/issues/210

## Description of changes being made ##
* Add support for reading multi-env local files to regular and safe modes (e.g. `.env.development.local`)