### PR TITLE
only replace `process.env` variable if value is defined

### DIFF
--- a/__tests__/__fixtures__/process-env-propagate/.babelrc
+++ b/__tests__/__fixtures__/process-env-propagate/.babelrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    ["../../../", {
+      "path": "__tests__/__fixtures__/process-env-propagate/.env",
+      "moduleName": "process.env"
+    }]
+  ]
+}

--- a/__tests__/__fixtures__/process-env-propagate/.env
+++ b/__tests__/__fixtures__/process-env-propagate/.env
@@ -1,0 +1,1 @@
+# empty on purpose

--- a/__tests__/__fixtures__/process-env-propagate/source.js
+++ b/__tests__/__fixtures__/process-env-propagate/source.js
@@ -1,0 +1,1 @@
+console.log(process.env.NODE_ENV)

--- a/__tests__/__fixtures__/process-env-undefined/.babelrc
+++ b/__tests__/__fixtures__/process-env-undefined/.babelrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    ["../../../", {
+      "path": "__tests__/__fixtures__/process-env-undefined/.env",
+      "moduleName": "process.env"
+    }]
+  ]
+}

--- a/__tests__/__fixtures__/process-env-undefined/.env
+++ b/__tests__/__fixtures__/process-env-undefined/.env
@@ -1,0 +1,1 @@
+# empty on purpose

--- a/__tests__/__fixtures__/process-env-undefined/source.js
+++ b/__tests__/__fixtures__/process-env-undefined/source.js
@@ -1,0 +1,1 @@
+console.log(process.env.UNDEFINED_VAR)

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -90,6 +90,20 @@ describe('react-native-dotenv', () => {
     expect(code).toBe('console.log("abc123");\nconsole.log("username");\nconsole.log("test");')
   })
 
+  it('should not change undefined process.env variables', () => {
+    const {code} = transformFileSync(FIXTURES + 'process-env-undefined/source.js')
+    expect(code).toBe('console.log(process.env.UNDEFINED_VAR);')
+  })
+
+  it('should propagate process.env variables from node process', () => {
+    const customEnv = 'my-custom-env'
+    const backupNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = customEnv
+    const {code} = transformFileSync(FIXTURES + 'process-env-propagate/source.js')
+    expect(code).toBe(`console.log("${customEnv}");`)
+    process.env.NODE_ENV = backupNodeEnv
+  })
+
   it('should allow specifying the package module name', () => {
     const {code} = transformFileSync(FIXTURES + 'module-name/source.js')
     expect(code).toBe('// eslint-disable-next-line import/no-unresolved\nconsole.log("abc123");\nconsole.log("username");')

--- a/index.js
+++ b/index.js
@@ -81,7 +81,6 @@ module.exports = (api, options) => {
     const modeLocalParsed = parseDotenvFile(modeLocalFilePath, options.verbose)
 
     this.env = safeObjectAssign(Object.assign(Object.assign(Object.assign(parsed, modeParsed), localParsed), modeLocalParsed), dotenvTemporary, ['NODE_ENV', 'BABEL_ENV', options.envName])
-    this.env.NODE_ENV = process.env.NODE_ENV || babelMode
   } else {
     dotenv.config({
       path: modeLocalFilePath,
@@ -132,7 +131,6 @@ module.exports = (api, options) => {
         const modeParsed = parseDotenvFile(modeFilePath)
         const modeLocalParsed = parseDotenvFile(modeLocalFilePath)
         this.env = safeObjectAssign(Object.assign(Object.assign(Object.assign(parsed, modeParsed), localParsed), modeLocalParsed), dotenvTemporary, ['NODE_ENV', 'BABEL_ENV', options.envName])
-        this.env.NODE_ENV = process.env.NODE_ENV || babelMode
       } else {
         dotenv.config({
           path: modeLocalFilePath,
@@ -204,8 +202,9 @@ module.exports = (api, options) => {
           if (t.isStringLiteral(key)) {
             const importedId = key.value
             const value = (opts.env && importedId in opts.env) ? opts.env[importedId] : process.env[importedId]
-
-            path.replaceWith(t.valueToNode(value))
+            if (value !== undefined) {
+              path.replaceWith(t.valueToNode(value))
+            }
           }
         }
       },


### PR DESCRIPTION
This fixes https://github.com/goatandsheep/react-native-dotenv/issues/251#issuecomment-1066200376

react-native sets the `NODE_ENV` **after** this transformation happens.
Code that directly access `process.env.NODE_ENV` was replaced by `babelMode` during transformation (if latest babel was used) or by `undefined`.

With this commit, any access to a `process.env` variable is only replaced by the corresponding value if its value is set.