### PR TITLE
feat: support destructing of process.env

### DIFF
--- a/__tests__/__fixtures__/process-env-object-pattern/.babelrc
+++ b/__tests__/__fixtures__/process-env-object-pattern/.babelrc
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    ["../../../", {
+      "path": "__tests__/__fixtures__/process-env-object-pattern/.env",
+      "blacklist": null,
+      "whitelist": null,
+      "safe": false,
+      "allowUndefined": true
+    }]
+  ]
+}

--- a/__tests__/__fixtures__/process-env-object-pattern/.env
+++ b/__tests__/__fixtures__/process-env-object-pattern/.env
@@ -1,0 +1,2 @@
+API_KEY=abc123
+DEV_USERNAME=username

--- a/__tests__/__fixtures__/process-env-object-pattern/source.js
+++ b/__tests__/__fixtures__/process-env-object-pattern/source.js
@@ -1,2 +1,2 @@
-const {API_KEY, NODE_ENV, DEV_USERNAME} = process.env;
-console.log(API_KEY, NODE_ENV, DEV_USERNAME);
+const {API_KEY, NODE_ENV, DEV_USERNAME} = process.env
+console.log(API_KEY, NODE_ENV, DEV_USERNAME)

--- a/__tests__/__fixtures__/process-env-object-pattern/source.js
+++ b/__tests__/__fixtures__/process-env-object-pattern/source.js
@@ -1,0 +1,2 @@
+const {API_KEY, NODE_ENV, DEV_USERNAME} = process.env;
+console.log(API_KEY, NODE_ENV, DEV_USERNAME);

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -90,6 +90,18 @@ describe('react-native-dotenv', () => {
     expect(code).toBe('console.log("abc123");\nconsole.log("username");\nconsole.log("test");')
   })
 
+  it('should allow specifying process.env with multiple variable destructuring', () => {
+    const {code} = transformFileSync(FIXTURES + 'process-env-object-pattern/source.js')
+    const output = `const {
+  API_KEY = "abc123",
+  NODE_ENV = "test",
+  DEV_USERNAME = "username"
+} = process.env;
+console.log(API_KEY, NODE_ENV, DEV_USERNAME);`
+
+    expect(code).toBe(output)
+  })
+
   it('should allow specifying the package module name', () => {
     const {code} = transformFileSync(FIXTURES + 'module-name/source.js')
     expect(code).toBe('// eslint-disable-next-line import/no-unresolved\nconsole.log("abc123");\nconsole.log("username");')

--- a/index.js
+++ b/index.js
@@ -199,20 +199,20 @@ module.exports = (api, options) => {
         }
       },
       MemberExpression(path) {
-        const hasEnv = (key) => this.env[key] !== undefined;
-        const getValue = (key) => this.env[key];
+        const hasEnv = key => this.env[key] !== undefined
+        const getValue = key => this.env[key]
 
         // Input:  process.env.VARIABLE1
         // Output: "VALUE1"
         if (path.get('object').matchesPattern('process.env')) {
-          const keyObj = path.toComputedKey();
-          if (t.isStringLiteral(keyObj)) {
-            const key = keyObj.value
+          const keyObject = path.toComputedKey()
+          if (t.isStringLiteral(keyObject)) {
+            const key = keyObject.value
             if (!hasEnv(key)) {
-              return;
+              return
             }
 
-            const value = getValue(key);
+            const value = getValue(key)
             path.replaceWith(t.valueToNode(value))
           }
         }
@@ -220,20 +220,20 @@ module.exports = (api, options) => {
         // Input:  const {VARIABLE1} = process.env
         // Output: const {VARIABLE1 = "VALUE1"} = process.env
         if (path.matchesPattern('process.env')) {
-          const {parent} = path;
+          const {parent} = path
 
-          if (parent.type === "VariableDeclarator" && parent.id.type === 'ObjectPattern') {
+          if (parent.type === 'VariableDeclarator' && parent.id.type === 'ObjectPattern') {
             for (const variable of parent.id.properties) {
-              const key = variable.key.name;
+              const key = variable.key.name
               if (!hasEnv(key)) {
-                return;
+                return
               }
 
-              const value = getValue(key);
+              const value = getValue(key)
               variable.value = t.assignmentPattern(
                 variable.value,
                 t.stringLiteral(value),
-              );
+              )
             }
           }
         }


### PR DESCRIPTION
## Link to issue ##

https://github.com/goatandsheep/react-native-dotenv/issues/323

## Description of changes being made ##

* What was the solution to the problem?

Transforming 

`const {VARIABLE1, VARIABLE2} = process.env;`

to

`const {VARIABLE1 = "VALUE1", VARIABLE2 = "VALUE2" } = process.env;`

