### PR TITLE
Add option to ignore process.env when on CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ You can disable this now
 {
   "plugins": [
     ["module:react-native-dotenv", {
-      "ci": true
+      "ignoreProcessEnv": true
     }]
   ]
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Many have been asking about the reasons behind recent changes in this repo. Plea
 
 ## Introduction
 
-This babel plugin lets you inject your environment variables into your Javascript environment using dotenv for multiple environments. It is best suited for use with react native and works with all flavors including web. 
+This babel plugin lets you inject your environment variables into your Javascript environment using dotenv for multiple environments. It is best suited for use with react native and works with all flavors including web.
 
 ## Usage
 
@@ -52,7 +52,8 @@ If the defaults do not cut it for your project, this outlines the available opti
       "whitelist": null, // DEPRECATED
       "safe": false,
       "allowUndefined": true,
-      "verbose": false
+      "verbose": false,
+      "ci": false
     }]
   ]
 }
@@ -190,6 +191,24 @@ Now you can define `MY_ENV`:
 ```
 
 Note: if you're using `APP_ENV` (or `envName`), you should avoid using `development` nor `production` as values, and you should avoid having a `.env.development` or `.env.production`. This is a Babel and Node thing that I have little control over unfortunately and is consistent with many other platforms that have an override option, like [Gatsby](https://www.gatsbyjs.com/docs/how-to/local-development/environment-variables/#additional-environments-staging-test-etc). If you want to use `development` and `production`, you should not use `APP_ENV` (or `envName`), but rather the built-in `NODE_ENV=development` or `NODE_ENV=production`.
+
+## Ignoring CI environment variables
+
+In some cases you may have issues where your environment specific variables are ignored by your continuous integration platform.
+
+You can disable this now
+
+```json
+{
+  "plugins": [
+    ["module:react-native-dotenv", {
+      "ci": true
+    }]
+  ]
+}
+```
+
+This will then only allow the environment specific variables you define and ignore anything that might have been injected into the environment from the CI.
 
 
 ## Multi-env

--- a/__tests__/__fixtures__/ignore-process-env/.babelrc
+++ b/__tests__/__fixtures__/ignore-process-env/.babelrc
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    [
+      "../../../",
+      {
+        "path": "__tests__/__fixtures__/ignore-process-env/.env",
+        "ignoreProcessEnv": true
+      }
+    ]
+  ]
+}

--- a/__tests__/__fixtures__/ignore-process-env/.env
+++ b/__tests__/__fixtures__/ignore-process-env/.env
@@ -1,0 +1,2 @@
+API_KEY=abc123
+DEV_USERNAME=username

--- a/__tests__/__fixtures__/ignore-process-env/source.js
+++ b/__tests__/__fixtures__/ignore-process-env/source.js
@@ -1,0 +1,4 @@
+import {API_KEY, DEV_USERNAME} from '@env'
+
+console.log(API_KEY)
+console.log(DEV_USERNAME)

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -181,13 +181,13 @@ describe('react-native-dotenv', () => {
     expect(code).toBe('console.log("abc123456");\nconsole.log("username123456");')
   })
 
-  it("should ignore environment variables when ignoreProcessEnv is true", () => {
-    process.env.API_KEY = "i win";
-    process.env.DEV_USERNAME = "not me";
+  it('should ignore environment variables when ignoreProcessEnv is true', () => {
+    process.env.API_KEY = 'i win'
+    process.env.DEV_USERNAME = 'not me'
 
-    const { code } = transformFileSync(
-      FIXTURES + "ignore-process-env/source.js"
-    );
-    expect(code).toBe('console.log("abc123");\nconsole.log("username");');
-  });
+    const {code} = transformFileSync(
+      FIXTURES + 'ignore-process-env/source.js',
+    )
+    expect(code).toBe('console.log("abc123");\nconsole.log("username");')
+  })
 })

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -180,4 +180,14 @@ describe('react-native-dotenv', () => {
     const {code} = transformFileSync(FIXTURES + 'env-name/source.js')
     expect(code).toBe('console.log("abc123456");\nconsole.log("username123456");')
   })
+
+  it("should ignore environment variables when ignoreProcessEnv is true", () => {
+    process.env.API_KEY = "i win";
+    process.env.DEV_USERNAME = "not me";
+
+    const { code } = transformFileSync(
+      FIXTURES + "ignore-process-env/source.js"
+    );
+    expect(code).toBe('console.log("abc123");\nconsole.log("username");');
+  });
 })

--- a/index.js
+++ b/index.js
@@ -59,9 +59,9 @@ module.exports = (api, options) => {
   const t = api.types
   let env = {}
   options = {
-    envName: "APP_ENV",
-    moduleName: "@env",
-    path: ".env",
+    envName: 'APP_ENV',
+    moduleName: '@env',
+    path: '.env',
     whitelist: null,
     blacklist: null,
     allowlist: null,
@@ -71,7 +71,7 @@ module.exports = (api, options) => {
     verbose: false,
     ignoreProcessEnv: false,
     ...options,
-  };
+  }
   const babelMode = process.env[options.envName] || (process.env.BABEL_ENV && process.env.BABEL_ENV !== 'undefined' && process.env.BABEL_ENV !== 'development' && process.env.BABEL_ENV) || process.env.NODE_ENV || 'development'
   const localFilePath = options.path + '.local'
   const modeFilePath = options.path + '.' + babelMode
@@ -88,7 +88,7 @@ module.exports = (api, options) => {
 
   const dotenvTemporary = options.ignoreProcessEnv
     ? {}
-    : undefObjectAssign({}, process.env);
+    : undefObjectAssign({}, process.env)
   const parsed = parseDotenvFile(options.path, options.verbose)
   const localParsed = parseDotenvFile(localFilePath, options.verbose)
   const modeParsed = parseDotenvFile(modeFilePath, options.verbose)
@@ -140,10 +140,10 @@ module.exports = (api, options) => {
               const binding = path.scope.getBinding(localId)
               for (const refPath of binding.referencePaths) {
                 try {
-                  refPath.replaceWith(t.valueToNode(env[importedId]));
-                } catch (e) {
-                  refPath.scope.crawl();
-                  refPath.replaceWith(t.valueToNode(env[importedId]));
+                  refPath.replaceWith(t.valueToNode(env[importedId]))
+                } catch {
+                  refPath.scope.crawl()
+                  refPath.replaceWith(t.valueToNode(env[importedId]))
                 }
               }
             }

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = (api, options) => {
     safe: false,
     allowUndefined: true,
     verbose: false,
-    ci: false,
+    ignoreProcessEnv: false,
     ...options,
   };
   const babelMode = process.env[options.envName] || (process.env.BABEL_ENV && process.env.BABEL_ENV !== 'undefined' && process.env.BABEL_ENV !== 'development' && process.env.BABEL_ENV) || process.env.NODE_ENV || 'development'
@@ -86,7 +86,9 @@ module.exports = (api, options) => {
   api.cache.using(() => mtime(modeFilePath))
   api.cache.using(() => mtime(modeLocalFilePath))
 
-  const dotenvTemporary = undefObjectAssign({}, options.ci ? {} : process.env);
+  const dotenvTemporary = options.ignoreProcessEnv
+    ? {}
+    : undefObjectAssign({}, process.env);
   const parsed = parseDotenvFile(options.path, options.verbose)
   const localParsed = parseDotenvFile(localFilePath, options.verbose)
   const modeParsed = parseDotenvFile(modeFilePath, options.verbose)


### PR DESCRIPTION
My team found during an upgrade to react native, along with many other packages, that a change occurred that caused our `.env.test` to be ignored in favour of the environment variables injected via the CI. This appeared to only be the case when running `yarn test --coverage`.

Interestingly, when changing the `coverageProvider` to "v8", the environment variables were correct. But that didn't solve all our issues and raised other significantly complex issues.

Part of the solution took inspiration from this PR: https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill/pull/156/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556

## Link to issue ##

 fixes #410 This is a solution we felt that the community might benefit from.

## Description of changes being made ##

* An extra option of `ci` has been added, which will allow the `process.env` variables to be ignored. The reason we got into this scenario was due to the environment variables in Circle CI being included in the initial temporary object and then subsequent values appeared to be ignored.
* The update to `ImportDeclaration()` was a fix (link up above) for "container is falsey" that was found when running `yarn jest --coverage`.
* Both changes were required to solve the overall issue.
