### PR TITLE
fixes #415

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,6 @@ Add all of your .env variables inside this module.
 {
 ...
     "typeRoots": ["./src/types"],
-    ""
 ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 $ npm install -D react-native-dotenv
 ```
 
+If you are using Yarn:
+
+```sh
+$ yarn add -D react-native-dotenv
+```
+
 **Breaking changes**: moving from `v0.x` to `v2.x` changes both the setup and usage of this package. Please see the [migration guide](https://github.com/goatandsheep/react-native-dotenv/wiki/Migration-Guide).
 
 Many have been asking about the reasons behind recent changes in this repo. Please see the [story wiki page](https://github.com/goatandsheep/react-native-dotenv/wiki/Story-of-this-repo).
@@ -240,6 +246,7 @@ Add all of your .env variables inside this module.
 {
 ...
     "typeRoots": ["./src/types"],
+    ""
 ...
 }
 ```

--- a/index.js
+++ b/index.js
@@ -81,8 +81,8 @@ module.exports = (api, options) => {
   }
 
   api.cache.using(() => mtime(options.path))
-  api.cache.using(() => mtime(localFilePath))
   api.cache.using(() => mtime(modeFilePath))
+  api.cache.using(() => mtime(localFilePath))
   api.cache.using(() => mtime(modeLocalFilePath))
 
   const dotenvTemporary = undefObjectAssign({}, process.env)
@@ -90,12 +90,12 @@ module.exports = (api, options) => {
   const localParsed = parseDotenvFile(localFilePath, options.verbose)
   const modeParsed = parseDotenvFile(modeFilePath, options.verbose)
   const modeLocalParsed = parseDotenvFile(modeLocalFilePath, options.verbose)
-  env = (options.safe) ? safeObjectAssign(undefObjectAssign(undefObjectAssign(undefObjectAssign(parsed, localParsed), modeParsed), modeLocalParsed), dotenvTemporary, ['NODE_ENV', 'BABEL_ENV', options.envName])
-    : undefObjectAssign(undefObjectAssign(undefObjectAssign(undefObjectAssign(parsed, localParsed), modeParsed), modeLocalParsed), dotenvTemporary)
+  env = (options.safe) ? safeObjectAssign(undefObjectAssign(undefObjectAssign(undefObjectAssign(parsed, modeParsed), localParsed), modeLocalParsed), dotenvTemporary, ['NODE_ENV', 'BABEL_ENV', options.envName])
+    : undefObjectAssign(undefObjectAssign(undefObjectAssign(undefObjectAssign(parsed, modeParsed), localParsed), modeLocalParsed), dotenvTemporary)
 
   api.addExternalDependency(path.resolve(options.path))
-  api.addExternalDependency(path.resolve(localFilePath))
   api.addExternalDependency(path.resolve(modeFilePath))
+  api.addExternalDependency(path.resolve(localFilePath))
   api.addExternalDependency(path.resolve(modeLocalFilePath))
 
   return ({

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const {readFileSync, statSync} = require('fs')
+const fs = require('fs')
 const path = require('path')
 const dotenv = require('dotenv')
 
@@ -6,7 +6,7 @@ function parseDotenvFile(path, verbose = false) {
   let content
 
   try {
-    content = readFileSync(path)
+    content = fs.readFileSync(path)
   } catch (error) {
     // The env file does not exist.
     if (verbose) {
@@ -49,7 +49,7 @@ function safeObjectAssign(targetObject, sourceObject, exceptions = []) {
 
 function mtime(filePath) {
   try {
-    return statSync(filePath).mtimeMs
+    return fs.statSync(filePath).mtimeMs
   } catch {
     return null
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dotenv": "^16.0.3"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.5",
     "codecov": "^3.8.3",
     "jest": "29.3.1",
     "jest-junit": "^15.0.0",
@@ -61,7 +62,6 @@
     ]
   },
   "peerDependencies": {
-    "@babel/core": "^7.20.5",
     "@babel/runtime": "^7.20.6"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   },
   "author": "Kemal Ahmed",
   "license": "MIT",
+  "files": [
+    "index.js"
+  ],
   "jest": {
     "testEnvironment": "node",
     "testPathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-dotenv",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "description": "Load environment variables using import statements.",
   "repository": "github:goatandsheep/react-native-dotenv",
   "homepage": "https://github.com/goatandsheep/react-native-dotenv",


### PR DESCRIPTION
## Link to issue ##

* fixes #415
* readme updates
* fixes #408

## Description of changes being made ##

* dotenv flow order dictates path < mode < local < localMode NOT path < local < mode < localMode
* commonjs issue pertaining to esmoduleinterop. Essentially changing the fs import is important because it messes up TypeScript. Otherwise this can only be solved using the esModuleInterop flag. Let's make it easier for TypeScript users
