### PR TITLE
Follow dotenv-flow variable precedence

### DIFF
--- a/__tests__/__fixtures__/dotenv-flow-explicit-local/.babelrc
+++ b/__tests__/__fixtures__/dotenv-flow-explicit-local/.babelrc
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["../../../", {
+      "path": "__tests__/__fixtures__/dotenv-flow/.env"
+    }]
+  ]
+}

--- a/__tests__/__fixtures__/dotenv-flow-explicit-local/.env
+++ b/__tests__/__fixtures__/dotenv-flow-explicit-local/.env
@@ -1,0 +1,1 @@
+API_KEY=default-key

--- a/__tests__/__fixtures__/dotenv-flow-explicit-local/.env.development
+++ b/__tests__/__fixtures__/dotenv-flow-explicit-local/.env.development
@@ -1,0 +1,1 @@
+API_KEY=development-key

--- a/__tests__/__fixtures__/dotenv-flow-explicit-local/.env.development.local
+++ b/__tests__/__fixtures__/dotenv-flow-explicit-local/.env.development.local
@@ -1,0 +1,1 @@
+API_KEY=development-local-key

--- a/__tests__/__fixtures__/dotenv-flow-explicit-local/.env.local
+++ b/__tests__/__fixtures__/dotenv-flow-explicit-local/.env.local
@@ -1,0 +1,1 @@
+API_KEY=local-key

--- a/__tests__/__fixtures__/dotenv-flow-explicit-local/.env.production
+++ b/__tests__/__fixtures__/dotenv-flow-explicit-local/.env.production
@@ -1,0 +1,1 @@
+API_KEY=production-key

--- a/__tests__/__fixtures__/dotenv-flow-explicit-local/source.js
+++ b/__tests__/__fixtures__/dotenv-flow-explicit-local/source.js
@@ -1,0 +1,3 @@
+import {API_KEY} from '@env'
+
+console.log(API_KEY)

--- a/__tests__/__fixtures__/dotenv-flow-mode-local/.babelrc
+++ b/__tests__/__fixtures__/dotenv-flow-mode-local/.babelrc
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["../../../", {
+      "path": "__tests__/__fixtures__/dotenv-flow/.env"
+    }]
+  ]
+}

--- a/__tests__/__fixtures__/dotenv-flow-mode-local/.env
+++ b/__tests__/__fixtures__/dotenv-flow-mode-local/.env
@@ -1,0 +1,1 @@
+API_KEY=default-key

--- a/__tests__/__fixtures__/dotenv-flow-mode-local/.env.development
+++ b/__tests__/__fixtures__/dotenv-flow-mode-local/.env.development
@@ -1,0 +1,1 @@
+API_KEY=development-key

--- a/__tests__/__fixtures__/dotenv-flow-mode-local/.env.development.local
+++ b/__tests__/__fixtures__/dotenv-flow-mode-local/.env.development.local
@@ -1,0 +1,1 @@
+API_KEY=development-local-key

--- a/__tests__/__fixtures__/dotenv-flow-mode-local/.env.local
+++ b/__tests__/__fixtures__/dotenv-flow-mode-local/.env.local
@@ -1,0 +1,1 @@
+API_KEY=local-key

--- a/__tests__/__fixtures__/dotenv-flow-mode-local/.env.production
+++ b/__tests__/__fixtures__/dotenv-flow-mode-local/.env.production
@@ -1,0 +1,1 @@
+API_KEY=production-key

--- a/__tests__/__fixtures__/dotenv-flow-mode-local/source.js
+++ b/__tests__/__fixtures__/dotenv-flow-mode-local/source.js
@@ -1,0 +1,3 @@
+import {API_KEY} from '@env'
+
+console.log(API_KEY)

--- a/__tests__/__fixtures__/dotenv-flow-mode/.babelrc
+++ b/__tests__/__fixtures__/dotenv-flow-mode/.babelrc
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["../../../", {
+      "path": "__tests__/__fixtures__/dotenv-flow/.env"
+    }]
+  ]
+}

--- a/__tests__/__fixtures__/dotenv-flow-mode/.env
+++ b/__tests__/__fixtures__/dotenv-flow-mode/.env
@@ -1,0 +1,1 @@
+API_KEY=default-key

--- a/__tests__/__fixtures__/dotenv-flow-mode/.env.development
+++ b/__tests__/__fixtures__/dotenv-flow-mode/.env.development
@@ -1,0 +1,1 @@
+API_KEY=development-key

--- a/__tests__/__fixtures__/dotenv-flow-mode/.env.development.local
+++ b/__tests__/__fixtures__/dotenv-flow-mode/.env.development.local
@@ -1,0 +1,1 @@
+API_KEY=development-local-key

--- a/__tests__/__fixtures__/dotenv-flow-mode/.env.local
+++ b/__tests__/__fixtures__/dotenv-flow-mode/.env.local
@@ -1,0 +1,1 @@
+API_KEY=local-key

--- a/__tests__/__fixtures__/dotenv-flow-mode/.env.production
+++ b/__tests__/__fixtures__/dotenv-flow-mode/.env.production
@@ -1,0 +1,1 @@
+API_KEY=production-key

--- a/__tests__/__fixtures__/dotenv-flow-mode/source.js
+++ b/__tests__/__fixtures__/dotenv-flow-mode/source.js
@@ -1,0 +1,3 @@
+import {API_KEY} from '@env'
+
+console.log(API_KEY)

--- a/__tests__/__fixtures__/dotenv-flow/.babelrc
+++ b/__tests__/__fixtures__/dotenv-flow/.babelrc
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["../../../", {
+      "path": "__tests__/__fixtures__/dotenv-flow/.env"
+    }]
+  ]
+}

--- a/__tests__/__fixtures__/dotenv-flow/.env
+++ b/__tests__/__fixtures__/dotenv-flow/.env
@@ -1,0 +1,1 @@
+API_KEY=default-key

--- a/__tests__/__fixtures__/dotenv-flow/.env.development
+++ b/__tests__/__fixtures__/dotenv-flow/.env.development
@@ -1,0 +1,1 @@
+API_KEY=development-key

--- a/__tests__/__fixtures__/dotenv-flow/.env.development.local
+++ b/__tests__/__fixtures__/dotenv-flow/.env.development.local
@@ -1,0 +1,1 @@
+API_KEY=development-local-key

--- a/__tests__/__fixtures__/dotenv-flow/.env.local
+++ b/__tests__/__fixtures__/dotenv-flow/.env.local
@@ -1,0 +1,1 @@
+API_KEY=local-key

--- a/__tests__/__fixtures__/dotenv-flow/.env.production
+++ b/__tests__/__fixtures__/dotenv-flow/.env.production
@@ -1,0 +1,1 @@
+API_KEY=production-key

--- a/__tests__/__fixtures__/dotenv-flow/source.js
+++ b/__tests__/__fixtures__/dotenv-flow/source.js
@@ -1,0 +1,3 @@
+import {API_KEY} from '@env'
+
+console.log(API_KEY)

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -198,4 +198,30 @@ describe('react-native-dotenv', () => {
     const {code} = transformFileSync(FIXTURES + 'env-name/source.js')
     expect(code).toBe('console.log("abc123456");\nconsole.log("username123456");')
   })
+
+  it('should follow dotenv-flow variable precedence (default)', () => {
+    const {code} = transformFileSync(FIXTURES + 'dotenv-flow/source.js')
+    expect(code).toBe('console.log("local-key");')
+  })
+
+  it('should follow dotenv-flow variable precedence (mode)', () => {
+    process.env.NODE_ENV = 'production'
+
+    const {code} = transformFileSync(FIXTURES + 'dotenv-flow-mode/source.js', {})
+    expect(code).toBe('console.log("production-key");')
+  })
+
+  it('should follow dotenv-flow variable precedence (mode local)', () => {
+    process.env.NODE_ENV = 'development'
+
+    const {code} = transformFileSync(FIXTURES + 'dotenv-flow-mode-local/source.js', {})
+    expect(code).toBe('console.log("development-local-key");')
+  })
+
+  it('should follow dotenv-flow variable precedence (explicit local)', () => {
+    process.env.NODE_ENV = 'local'
+
+    const {code} = transformFileSync(FIXTURES + 'dotenv-flow-explicit-local/source.js', {})
+    expect(code).toBe('console.log("local-key");')
+  })
 })

--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ function mtime(filePath) {
 
 module.exports = (api, options) => {
   const t = api.types
-  let env = {}
   options = {
     envName: 'APP_ENV',
     moduleName: '@env',
@@ -93,8 +92,15 @@ module.exports = (api, options) => {
   const localParsed = parseDotenvFile(localFilePath, options.verbose)
   const modeParsed = parseDotenvFile(modeFilePath, options.verbose)
   const modeLocalParsed = parseDotenvFile(modeLocalFilePath, options.verbose)
-  env = (options.safe) ? safeObjectAssign(undefObjectAssign(undefObjectAssign(undefObjectAssign(parsed, modeParsed), localParsed), modeLocalParsed), dotenvTemporary, ['NODE_ENV', 'BABEL_ENV', options.envName])
-    : undefObjectAssign(undefObjectAssign(undefObjectAssign(undefObjectAssign(parsed, modeParsed), localParsed), modeLocalParsed), dotenvTemporary)
+
+  let env = parsed
+  env = undefObjectAssign(env, localParsed)
+  env = undefObjectAssign(env, modeParsed)
+  env = undefObjectAssign(env, modeLocalParsed)
+
+  env = options.safe ?
+    safeObjectAssign(env, dotenvTemporary, ['NODE_ENV', 'BABEL_ENV', options.envName]) :
+    undefObjectAssign(env, dotenvTemporary)
 
   api.addExternalDependency(path.resolve(options.path))
   api.addExternalDependency(path.resolve(modeFilePath))


### PR DESCRIPTION
## Link to issue ##

Resolves #491

## Description of changes being made ##

- Change the order of merging multiple variables to:
  1. Default env file (.env)
  2. Local env file (.env.local)
  3. Mode env file (.env.my-env)
  4. Mode local env file (.env.my-env.local)
  5. Command line variables

- Add test cases for the variable precedence.