### PR TITLE
fix: guard optional Babel dependency tracking API

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -162,6 +162,18 @@ describe('react-native-dotenv', () => {
     expect(code).toBe('console.log(undefined);')
   })
 
+  it('should support Babel API versions without addExternalDependency', () => {
+    const plugin = require('../index.js')
+    const api = {
+      types: {},
+      cache: {
+        using: jest.fn(),
+      },
+    }
+
+    expect(() => plugin(api, {path: FIXTURES + 'default/.env'})).not.toThrow()
+  })
+
   it('should not throw if .env exists in safe mode', () => {
     const {code} = transformFileSync(FIXTURES + 'safe-no-dotenv/source.js')
     expect(code).toBe('console.log(undefined);')

--- a/index.js
+++ b/index.js
@@ -96,10 +96,12 @@ module.exports = (api, options) => {
   env = (options.safe) ? safeObjectAssign(undefObjectAssign(undefObjectAssign(undefObjectAssign(parsed, modeParsed), localParsed), modeLocalParsed), dotenvTemporary, ['NODE_ENV', 'BABEL_ENV', options.envName])
     : undefObjectAssign(undefObjectAssign(undefObjectAssign(undefObjectAssign(parsed, modeParsed), localParsed), modeLocalParsed), dotenvTemporary)
 
-  api.addExternalDependency(path.resolve(options.path))
-  api.addExternalDependency(path.resolve(modeFilePath))
-  api.addExternalDependency(path.resolve(localFilePath))
-  api.addExternalDependency(path.resolve(modeLocalFilePath))
+  if (typeof api.addExternalDependency === 'function') {
+    api.addExternalDependency(path.resolve(options.path))
+    api.addExternalDependency(path.resolve(modeFilePath))
+    api.addExternalDependency(path.resolve(localFilePath))
+    api.addExternalDependency(path.resolve(modeLocalFilePath))
+  }
 
   return ({
     name: 'dotenv-import',


### PR DESCRIPTION
## Summary
  - Guard `api.addExternalDependency` so older Babel API objects do not throw.
  - Add regression coverage for Babel API versions without `addExternalDependency`.

  ## Tests
  - yarn test
  - yarn lint