### PR TITLE
Preserve env references inside worklets

### DIFF
--- a/__tests__/__fixtures__/worklet/.babelrc
+++ b/__tests__/__fixtures__/worklet/.babelrc
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["../../../", {
+      "path": "__tests__/__fixtures__/worklet/.env"
+    }]
+  ]
+}

--- a/__tests__/__fixtures__/worklet/.env
+++ b/__tests__/__fixtures__/worklet/.env
@@ -1,0 +1,1 @@
+API_KEY=abc123

--- a/__tests__/__fixtures__/worklet/source.js
+++ b/__tests__/__fixtures__/worklet/source.js
@@ -1,0 +1,7 @@
+import {API_KEY} from '@env'
+
+function onUpdate() {
+  'worklet'
+
+  console.log(API_KEY)
+}

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -86,6 +86,11 @@ describe('react-native-dotenv', () => {
     expect(code).toBe('const a = "abc123";\nconst b = "username";')
   })
 
+  it('should preserve worklet function references when importing environment variables', () => {
+    const {code} = transformFileSync(FIXTURES + 'worklet/source.js')
+    expect(code).toBe('const API_KEY = "abc123";\nfunction onUpdate() {\n  \'worklet\';\n\n  console.log(API_KEY);\n}')
+  })
+
   it('should allow specifying a custom module name', () => {
     const {code} = transformFileSync(FIXTURES + 'custom-module/source.js')
     expect(code).toBe('console.log("abc123");\nconsole.log("username");')

--- a/index.js
+++ b/index.js
@@ -55,6 +55,14 @@ function mtime(filePath) {
   }
 }
 
+function isWorkletFunction(path) {
+  return path.isFunction() && path.node.body && Array.isArray(path.node.body.directives) && path.node.body.directives.some(directive => directive.value.value === 'worklet')
+}
+
+function isInsideWorkletFunction(path) {
+  return Boolean(path.findParent(parentPath => isWorkletFunction(parentPath)))
+}
+
 module.exports = (api, options) => {
   const t = api.types
   let env = {}
@@ -106,6 +114,8 @@ module.exports = (api, options) => {
     visitor: {
       ImportDeclaration(path) {
         if (path.node.source.value === options.moduleName) {
+          const declarations = []
+
           for (const [index, specifier] of path.node.specifiers.entries()) {
             if (specifier.type === 'ImportDefaultSpecifier') {
               throw path.get('specifiers')[index].buildCodeFrameError('Default import is not supported')
@@ -138,13 +148,24 @@ module.exports = (api, options) => {
               }
 
               const binding = path.scope.getBinding(localId)
-              for (const referencePath of binding.referencePaths) {
-                referencePath.replaceWith(t.valueToNode(env[importedId]))
+              const valueNode = t.valueToNode(env[importedId])
+              if (binding.referencePaths.some(referencePath => isInsideWorkletFunction(referencePath))) {
+                declarations.push(t.variableDeclaration('const', [
+                  t.variableDeclarator(t.identifier(localId), valueNode),
+                ]))
+              } else {
+                for (const referencePath of binding.referencePaths) {
+                  referencePath.replaceWith(t.cloneNode(valueNode))
+                }
               }
             }
           }
 
-          path.remove()
+          if (declarations.length > 0) {
+            path.replaceWithMultiple(declarations)
+          } else {
+            path.remove()
+          }
         }
       },
       MemberExpression(path) {


### PR DESCRIPTION
## Summary
- preserve imported env bindings when they are referenced inside `"worklet"` functions
- keep normal `@env` imports inlined for non-worklet usage
- add a regression test for Reanimated/worklet-style functions

## Verification
- `npm.cmd test -- --runInBand`
- `npm.cmd run lint`
- `git diff --check`

Fixes #565.